### PR TITLE
fix-install: Remove 'sudo' commands in fix-install

### DIFF
--- a/library/fix-install.sh
+++ b/library/fix-install.sh
@@ -25,21 +25,21 @@ cd $(dirname $0) || exit 1
 # Rsync'ing over a git clone is bobo... fix the permissions and add missing
 # directories/links.
 
-sudo mkdir -p !portal!/webvar
-sudo chown !wwwuid!:!wwwgid! !portal!/webvar
+mkdir -p !portal!/webvar
+chown !wwwuid!:!wwwgid! !portal!/webvar
 for sub in badpgp ml_keys pgpkeys tmp; do
-  sudo mkdir -p !portal!/webvar/${sub}
-  sudo chown -R !wwwuid!:!wwwgid! !portal!/webvar/${sub}
-  sudo chmod 755 !portal!/webvar/${sub}
+  mkdir -p !portal!/webvar/${sub}
+  chown -R !wwwuid!:!wwwgid! !portal!/webvar/${sub}
+  chmod 755 !portal!/webvar/${sub}
 done
 
-sudo chmod -R 770 !portal!/webvar/ml_keys
-sudo chmod -R 770 !portal!/webvar/pgpkeys
-sudo chmod -R 775 !portal!/webvar
-sudo chmod -R 775 !portal!/webroot
+chmod -R 770 !portal!/webvar/ml_keys
+chmod -R 770 !portal!/webvar/pgpkeys
+chmod -R 775 !portal!/webvar
+chmod -R 775 !portal!/webroot
 
 for dir in logs webroot; do
-  sudo chown -R root:sudo !portal!/${dir}
+  chown -R root:sudo !portal!/${dir}
 done
 
 for masondir in \

--- a/library/fix-install.sh
+++ b/library/fix-install.sh
@@ -39,7 +39,7 @@ chmod -R 775 !portal!/webvar
 chmod -R 775 !portal!/webroot
 
 for dir in logs webroot; do
-  chown -R root:sudo !portal!/${dir}
+  chown -R root:0 !portal!/${dir}
 done
 
 for masondir in \


### PR DESCRIPTION
This script should only be run as root, and should fail in all other cases.

In a stock Debian environment, the 'sudo' command does not exist, and the fix-install script will fail when attempting to call 'sudo'. Installation of 'sudo' will fix the problem, however if we are not intending to install 'sudo' and use a stock Debian type of setup, then this is a wrong approach. This also applies to other environments which may not even have the 'sudo' command available to it.

If you are running 'make install' which calls this 'fix-install' script, you're either already using 'sudo' to run this to install, or you are already 'root' and don't need to gain permissions.  All other cases should fail since the command is not being run as superuser.