### PR TITLE
Fix cronrun-day and portal_query

### DIFF
--- a/library/cronrun-day.sh
+++ b/library/cronrun-day.sh
@@ -28,7 +28,7 @@ cron_lock $(basename $0)
 ./fsck-pgpkeys
 
 # Run notification bits for each trustgroup.
-for trustgroup in $(portal_query -A -t -c 'SELECT ident FROM trustgroup ORDER BY ident')
+for trustgroup in $($portal_query -A -t -c 'SELECT ident FROM trustgroup ORDER BY ident')
 do
 	./notify-unvetted $trustgroup
 	./report-unvetted $trustgroup

--- a/library/funcs.sh
+++ b/library/funcs.sh
@@ -68,10 +68,7 @@ cron_unlock()
 	fi
 }
 
-portal_query()
-{
-	psql -h ${PORTAL_DB_HOST} -p ${PORTAL_DB_PORT} -d ${PORTAL_DB_NAME}
-}
+export portal_query='psql -h ${PORTAL_DB_HOST} -p ${PORTAL_DB_PORT} -d ${PORTAL_DB_NAME}'
 
 portal_dump()
 {


### PR DESCRIPTION
There's a few reasons for these changes being required.

 1. The portal_query function as it was written would never have pulled in arguments form elsewhere.
 2. The portal_query function, even if arguments are passed in, would never receive single-quote items (such as used with `-c 'SELECT ...` as it was in the `cronrun-day` script).  Bash string handling happens before it gets ingested into arguments, which makes the use of this as a function irrelevant.
 3. Changing `portal_query` to a variable with the query string stored in it, and then calling it as a variable elsewhere, solves the issue of the queries hanging or failing.

Without such changes, the daily run cron script will fail to finish executing and fail to do what it is supposed to do.